### PR TITLE
docs: add description on top of ignored binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+# Binary data files
 *.dat


### PR DESCRIPTION
### Description

I didn't need to add `note.dat` in the `.gitignore` file because `*.dat` is already written in the `.gitignore` file. I've added the reason why we're ignoring `*.dat` files in the `.gitignore` so it's clear in the future.
https://github.com/arya2004/calendar-and-reminders/blob/9fe90f7fc8986eb1aa310ed1921f3cc4ba9fd3af/.gitignore#L54

Fixes #9 

### Type of changes
- Documentation update

### How Has This Been Tested?
N/A

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
