### PR TITLE
Added the indicator for Notes and Reminder, fixed #6

### DIFF
--- a/src/calendar.c
+++ b/src/calendar.c
@@ -68,11 +68,12 @@ void calendar_printer(int year, int month) {
             printf(" \t");
         } else {
             int isToday = (calender[i] == current_day && month == current_month && year == current_year);
+            char noteIndicator = checkNote(calender[i], month,year);
             
             if (isToday) {
-                printf("[%2i]\t", calender[i]); // Today: [25]
+                printf("[%2i%c]\t", calender[i], noteIndicator); // Today: [25*] or [25 ]
             } else {
-                printf("%3i\t", calender[i]); // Regular day: 25
+                printf("%3i%c\t", calender[i], noteIndicator); // Regular day: 25* or 25 
             }
         }
         if ((i + 1) % 7 == 0) {


### PR DESCRIPTION
### Description

This PR adds functionality to **show a reminder indicator in the calendar**.  
The `calendar_printer()` function in `calendar.c` was updated to **check if a note exists using `checkNote()`**.  
If a reminder is found for a specific date, the day is now displayed with an asterisk `*` — for example, `25*` instead of `25`.  

Additionally, as you mentioned earlier that notes were only associated with the **date**,  
the **recent commits merged by you have modified the logic**, and now **notes are associated with the date, month, and year** as well.  
Hence, this update aligns with the new data structure and ensures the reminder indicator works accordingly.

Fixes #6 

### Type of changes

- ✅ New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The implementation was tested by:
- **Adding notes/reminders** for specific dates and verifying the indicator (`*`) appears correctly.
- **Testing across different months and years** to ensure the reminder indicator works with the new date-month-year association.
- **Running the program without reminders** to confirm that the calendar display remains normal when no notes exist.

### Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation (if required)  
- [x] My changes generate no new warnings  
- [x] I have tested the feature locally and confirmed correct indicator behavior  
- [x] New and existing unit tests pass locally with my changes  
- [x] Any dependent changes have been merged and published in downstream modules  
