### PR TITLE
Refactor notes.c to avoid global variable R

### DIFF
--- a/include/notes.h
+++ b/include/notes.h
@@ -8,8 +8,6 @@ struct Remainder {
     char note[50];
 };
 
-extern struct Remainder R;
-
 char checkNote(int dd, int mm, int yy);
 void AddNote();
 void showNote(int mm, int yy);

--- a/src/notes.c
+++ b/src/notes.c
@@ -2,9 +2,8 @@
 #include <stdlib.h>
 #include "notes.h"
 
-struct Remainder R;
-
 char checkNote(int dd, int mm, int yy) {
+    struct Remainder R;
     FILE *fp;
     fp = fopen("note.dat", "rb");
     if (fp == NULL) {
@@ -21,6 +20,7 @@ char checkNote(int dd, int mm, int yy) {
 }
 
 void AddNote() {
+    struct Remainder R;
     FILE *fp;
     fp = fopen("note.dat", "ab+");
     printf("Enter the date (DD MM YYYY): ");
@@ -37,6 +37,7 @@ void AddNote() {
 }
 
 void showNote(int mm, int yy) {
+    struct Remainder R;
     FILE *fp;
     int i = 0, isFound = 0;
     fp = fopen("note.dat", "rb");


### PR DESCRIPTION
# Refactor: Remove global variable `R` from notes.c

## Description
This PR addresses the issue of removing the global variable `R` in `notes.c` and refactoring it to use local variable declarations instead.

## Problem Solved
- **Issue**: Global variable `struct Remainder R` was declared at file scope in `notes.c`
- **Impact**: Poor encapsulation, potential thread safety issues, and violation of best practices

## Changes Made

### Files Modified:
- `include/notes.h` - Removed `extern struct Remainder R;` declaration
- `src/notes.c` - Refactored to use local variables

### Specific Changes:
1. **Removed global scope declarations**:
   - Deleted `struct Remainder R;` from global scope in `notes.c`
   - Removed `extern struct Remainder R;` from `notes.h`

2. **Added local variable declarations**:
   - `checkNote()`: Now declares `struct Remainder R;` locally
   - `AddNote()`: Now declares `struct Remainder R;` locally  
   - `showNote()`: Now declares `struct Remainder R;` locally
   - `DeleteNote()`: Already used local variables (no changes needed)
