### PR TITLE
Added build/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ dkms.conf
 # Executables
 calendar_app
 build/tests/run_tests
+
+# Build output
+build/


### PR DESCRIPTION
# Pull Request: Add build/ directory to .gitignore

## Description
Added the `build/` directory to `.gitignore` to prevent local build outputs from being tracked.  
This keeps the repository clean and avoids accidental commits of compiled files.

**Fixes:** #30

## Type of changes
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## How Has This Been Tested?
- Created a `build/` directory locally and ran `git status` → confirmed it is ignored.  
- Rebuilt the project to ensure `.gitignore` works with other ignored files.

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-review completed  
- [x] No new warnings generated  
- [x] Tests pass locally
